### PR TITLE
Check for gzip by only reading first 3 bytes instead of fs.open

### DIFF
--- a/server.js
+++ b/server.js
@@ -72,9 +72,6 @@
             if (chunk.equals(gzipHeader)) {
                 res.header('Content-Encoding', 'gzip');
             }
-        });
-
-        readStream.on('close', function() {
             next();
         });
     }

--- a/server.js
+++ b/server.js
@@ -63,20 +63,19 @@
         var reqUrl = url.parse(req.url, true);
         var filePath = reqUrl.pathname.substring(1);
 
-        fs.open(filePath, 'r', function(status, fd) {
-            if (status) {
-                // Error opening file. Continue.
-                next();
-                return;
+        var readStream = fs.createReadStream(filePath, { start: 0, end: 2 });
+        readStream.on('error', function(err) {
+            next();
+        });
+
+        readStream.on('data', function(chunk) {
+            if (chunk.equals(gzipHeader)) {
+                res.header('Content-Encoding', 'gzip');
             }
-            fs.read(fd, buffer, 0, 3, 0, function(err, num) {
-                if (buffer.equals(gzipHeader)) {
-                    res.header('Content-Encoding', 'gzip');
-                }
-                fs.close(fd, function(err) {
-                    next();
-                });
-            });
+        });
+
+        readStream.on('close', function() {
+            next();
         });
     }
 


### PR DESCRIPTION
Related to https://github.com/AnalyticalGraphicsInc/3d-tiles-tools/issues/75 and https://github.com/AnalyticalGraphicsInc/3d-tiles-samples/pull/11#issuecomment-307770995

Once this is merged, I'll implement this in Cesium's server.js